### PR TITLE
Hotfix: double send (don't use /g for regex)

### DIFF
--- a/src/utils/dfx/constants.ts
+++ b/src/utils/dfx/constants.ts
@@ -6,4 +6,4 @@ export const NET_ID = {
   network: '00000000000000020101',
 };
 export const ROSETTA_URL = 'https://rosetta-api.internetcomputer.org';
-export const PRINCIPAL_REGEX = /(\w{5}-){10}\w{3}/g;
+export const PRINCIPAL_REGEX = /(\w{5}-){10}\w{3}/;


### PR DESCRIPTION
More info because I always use /g as well: If you use /g it preserves the state, so it starts after the last match until it hits no match and then restarts at the beginning of the string (which is why it was alternatives between `true` and `false`).