### PR TITLE
feat: return principal instead of identity at the toJSON method

### DIFF
--- a/src/PlugWallet/index.ts
+++ b/src/PlugWallet/index.ts
@@ -1,6 +1,5 @@
 import { KeyPair, Principal } from '@dfinity/agent';
 import { Ed25519KeyIdentity } from '@dfinity/identity';
-import { JsonnableEd25519KeyIdentity } from '@dfinity/identity/lib/cjs/identity/ed25519';
 
 import { createAccountFromMnemonic } from '../utils/account';
 import { createAgent, createLedgerActor } from '../utils/dfx';
@@ -17,7 +16,7 @@ interface PlugWalletArgs {
 interface JSONWallet {
   name: string;
   walletNumber: number;
-  identity: JsonnableEd25519KeyIdentity;
+  principalId: string;
   accountId: string;
   icon?: string;
 }
@@ -64,7 +63,7 @@ class PlugWallet {
   public toJSON = (): JSONWallet => ({
     name: this.name,
     walletNumber: this.walletNumber,
-    identity: this.identity.toJSON(),
+    principal: this.identity.getPrincipal.toString(),
     accountId: this.accountId,
     icon: this.icon,
   });


### PR DESCRIPTION
# feat: return principal instead of identity at the toJSON method

## WHAT

Return PrincipalId when method toJSON is call instead of return identity (private & public keys)

## WHY

We want keep keys inside controller