### PR TITLE
feat  🎸 generic actor generator

### DIFF
--- a/src/utils/dfx/index.ts
+++ b/src/utils/dfx/index.ts
@@ -3,7 +3,7 @@
 /* eslint-disable camelcase */
 import fetch from 'cross-fetch';
 import { config } from 'dotenv';
-import { HttpAgent, Actor, ActorSubclass } from '@dfinity/agent';
+import { HttpAgent, Actor, ActorSubclass, IDL } from '@dfinity/agent';
 import { Ed25519KeyIdentity } from '@dfinity/identity';
 
 import walletIDLFactory from '../../idls/walltet';
@@ -47,6 +47,21 @@ export const getCyclesWalletActor = async (
   );
   return actor;
 };
+
+export const createActor = <T>({
+  agent,
+  canisterId,
+  interfaceFactory,
+}: {
+  agent: HttpAgent;
+  actor: ActorSubclass<ActorSubclass<T>>;
+  canisterId: string;
+  interfaceFactory: IDL.InterfaceFactory;
+}): Promise<ActorSubclass<T>> =>
+  Actor.createActor(interfaceFactory, {
+    agent,
+    canisterId,
+  });
 
 export { createLedgerActor } from './ledger';
 export { createNNSActor } from './nns_uid';


### PR DESCRIPTION
## Why?

The end-user has to add the @dfinity/actor dependency and initialise separately to then wrap the `ic.plug.agent`.

The following PR, is a proposal for `createActor` in the Plug extension scope, which lets the user generate an actor through the provider API, without having to import @dfinity/actor dependencies separately or have the correct @dfinity/actor package version that is compatible with the one Plug uses.

## How?

- Created an dfx utility method `createActor`
- The `createActor` has 3 parameters (the agent, canisterId, and a interfaceFactory)
- Returns an Actor with the correct type definitions provided by the generic T

