### PR TITLE
docs: ✏️  description and location for the docgen for plug controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,9 @@ const wallet: PlugWallet = await keyRing.create(password);
 // Creates the keyring using the provided mnemonic and returns the default wallet
 const wallet: PlugWallet = await keyRing.importFromMnemonic(mnemonic, password);
 ```
+
+## Documentation
+
+Interface and Type definitions documents for the **@Psychedelic/plug-controller** implementation is provided in the following [location](https://twilight-dream-0902.on.fleek.co/).
+
+These are based in the `main release branch` and provide a good overview of the whole package (modules, IDL's, utils, etc).


### PR DESCRIPTION
## Why?

The documentation provides an overview of the package implementation, based on Typescript provided types and implementation and generated automatically. By having documentation that is generated from the source code, it's easier to reference parts of it that will always be in line with the implementation it provides.  Alternatively, making changes across different documents manually is prone to errors, hard to manage and asynchrony. Although it helps, it's still the best effort on providing good references to the end-user.

## How?

- Small description about the typedef and implementation docs
- A link to the documentation
