### PR TITLE
Use current wallet for getPublicKey and sign methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "typescript": "^3.8.3"
   },
   "name": "@psychedelic/plug-controller",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Internet Computer Plug wallet's controller",
   "main": "dist/index.js",
   "scripts": {

--- a/src/PlugKeyRing/index.ts
+++ b/src/PlugKeyRing/index.ts
@@ -44,10 +44,11 @@ class PlugKeyRing {
     this.isInitialized = !!state?.isInitialized;
   };
 
-  public getPublicKey = async (subaccount = 0): Promise<PublicKey> => {
+  public getPublicKey = async (subAccount = 0): Promise<PublicKey> => {
     await this.checkInitialized();
-    this.validateSubaccount(subaccount);
-    const wallet = this.state.wallets[subaccount];
+    const index = subAccount || this.state.currentWalletId || 0;
+    this.validateSubaccount(index);
+    const wallet = this.state.wallets[index];
     return wallet.publicKey;
   };
 
@@ -168,11 +169,12 @@ class PlugKeyRing {
 
   public sign = async (
     payload: BinaryBlob,
-    subaccount = 0
+    subAccount = 0
   ): Promise<BinaryBlob> => {
     this.checkUnlocked();
-    this.validateSubaccount(subaccount);
-    const wallet = this.state.wallets[subaccount];
+    const index = subAccount || this.state.currentWalletId || 0;
+    this.validateSubaccount(index);
+    const wallet = this.state.wallets[index];
     const signed = await wallet.sign(payload);
     return signed;
   };

--- a/src/interfaces/nft.ts
+++ b/src/interfaces/nft.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/camelcase */
 /* eslint-disable @typescript-eslint/class-name-casing */
 /* eslint-disable @typescript-eslint/interface-name-prefix */
-import type { Principal } from '@dfinity/agent';
+import type { Principal } from '@dfinity/principal';
 
 export type HeaderField = [
   string,


### PR DESCRIPTION
## Summary
First part of fixes for the multiple accounts on IC Provider API.
Made `getPublicKey` and `sign` methods use the current wallet id