### PR TITLE
KeyRing create options extended

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "typescript": "^3.8.3"
   },
   "name": "@psychedelic/plug-controller",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Internet Computer Plug wallet's controller",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Extended `create` and `createAndPersistKeyRing` methods with `name?: string` and `icon?: string` additional options
- Created interfaces for options objects

### Shortcut ticket(s)

https://app.shortcut.com/terminalsystems/story/23851/fix-default-account-emoji

### Explanation
On plug we should set default emoji when creating the account
-- this PR give a possibility to do that, as `create` method will now accept icon and name to provide them into `PlugWallet`

I found plainly typed objects with unassigned interfaces a bit dirty
@rocky-fleek please let me know if interfaces for options is something we want to have