### PR TITLE
Added optional rng parameter to make it rn compliant

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript": "^3.8.3"
   },
   "name": "@psychedelic/plug-controller",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Internet Computer Plug wallet's controller",
   "main": "dist/index.js",
   "scripts": {

--- a/src/PlugKeyRing/index.ts
+++ b/src/PlugKeyRing/index.ts
@@ -41,6 +41,7 @@ interface CreatePrincipalOptions {
 
 interface CreateOptions extends CreatePrincipalOptions {
   password: string;
+  rng?: (size: number) => Buffer;
 }
 
 interface CreateAndPersistKeyRingOptions extends CreateOptions {
@@ -160,11 +161,12 @@ class PlugKeyRing {
     password = '',
     icon,
     name,
+    rng,
   }: CreateOptions): Promise<{
     wallet: PlugWallet;
     mnemonic: string;
   }> => {
-    const { mnemonic } = createAccount();
+    const { mnemonic } = createAccount(rng);
     const wallet = await this.createAndPersistKeyRing({
       mnemonic,
       password,

--- a/src/utils/account/index.ts
+++ b/src/utils/account/index.ts
@@ -66,8 +66,10 @@ const getAccountCredentials = (
   };
 };
 
-export const createAccount = (): AccountCredentials => {
-  const mnemonic = bip39.generateMnemonic();
+export const createAccount = (
+  rng?: (size: number) => Buffer
+): AccountCredentials => {
+  const mnemonic = bip39.generateMnemonic(128, rng);
   return getAccountCredentials(mnemonic, 0);
 };
 


### PR DESCRIPTION
## Summary
- RandomBytes is not available in RN. Adding an optional callback param to inject rn-random-bytes when needed. 
- Defaults to prev behavior