### PR TITLE
CAP Transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "@dfinity/candid": "^0.9.3",
     "@dfinity/identity": "^0.9.3",
     "@dfinity/principal": "^0.9.3",
+    "@psychedelic/cap-js": "^0.0.5",
     "@psychedelic/dab-js": "0.2.4",
     "@types/secp256k1": "^4.0.3",
     "axios": "^0.21.1",

--- a/src/PlugKeyRing/plugKeyRing.test.ts
+++ b/src/PlugKeyRing/plugKeyRing.test.ts
@@ -95,29 +95,35 @@ const createManyTransactions = (): GetTransactionsResponse => {
     transactions.transactions.push({
       timestamp: RandomBigInt(32),
       hash: RandomBigInt(32),
-      from: 'string',
-      to: 'string',
-      amount: BigInt(1000),
-      currency: { symbol: 'ICP', decimals: 8 },
-      fee: {
+      details: {
+        from: 'string',
+        to: 'string',
         amount: BigInt(1000),
         currency: { symbol: 'ICP', decimals: 8 },
+        fee: {
+          amount: BigInt(1000),
+          currency: { symbol: 'ICP', decimals: 8 },
+        },
+        status: 'COMPLETED',
       },
-      status: 'COMPLETED',
       type: 'SEND',
+      caller: 'stirng',
     });
     transactions.transactions.push({
       timestamp: RandomBigInt(32),
       hash: RandomBigInt(32),
-      from: 'string',
-      to: 'string',
-      amount: BigInt(1000),
-      currency: { symbol: 'XTC', decimals: 5 },
-      fee: {
+      details: {
+        from: 'string',
+        to: 'string',
         amount: BigInt(1000),
         currency: { symbol: 'XTC', decimals: 5 },
+        fee: {
+          amount: BigInt(1000),
+          currency: { symbol: 'XTC', decimals: 5 },
+        },
+        status: 'COMPLETED',
       },
-      status: 'COMPLETED',
+      caller: 'string',
       type: 'SEND',
     });
   }

--- a/src/PlugWallet/index.ts
+++ b/src/PlugWallet/index.ts
@@ -331,8 +331,6 @@ class PlugWallet {
     const capTransactions = await getCapTransactions(this.principal);
     // merge and format all trx. sort by timestamp
     // TODO: any custom token impelmenting archive should be queried. (0.4.0)
-    console.log('cap transactions');
-    console.log(capTransactions);
     const transactions = {
       total: icpTrxs.total + xtcTransactions.total + capTransactions.total,
       transactions: [

--- a/src/utils/dab.ts
+++ b/src/utils/dab.ts
@@ -5,6 +5,7 @@ import {
 import { HttpAgent } from '@dfinity/agent';
 import fetch from 'cross-fetch';
 
+import { Principal } from '@dfinity/principal';
 import { IC_HOST } from './dfx/constants';
 
 export interface CanisterInfo {
@@ -32,7 +33,10 @@ export const getMultipleCanisterInfo = async (
   const finalAgent =
     agent || new HttpAgent({ host: process.env.DFX_HOST || IC_HOST, fetch });
 
-  const result = await getMultipleCanisterInfoFromDab(canisterIds, finalAgent);
+  const result = await getMultipleCanisterInfoFromDab(
+    canisterIds.map(id => Principal.from(id)),
+    finalAgent
+  );
 
   return result.map(canisterMetadata => ({
     ...canisterMetadata,

--- a/src/utils/dfx/history/cap.ts
+++ b/src/utils/dfx/history/cap.ts
@@ -1,0 +1,68 @@
+/* eslint-disable camelcase */
+/* eslint-disable no-underscore-dangle */
+import axios, { AxiosResponse } from 'axios';
+import { prettifyCapTransactions, TransactionPrettified } from '@psychedelic/cap-js';
+import { CanisterInfo, getMultipleCanisterInfo } from '../../dab';
+
+const KYASHU_URL = 'https://kyasshu.fleek.co';
+
+interface KyashuItem {
+  event: any;
+  pk: string;
+  sk: string;
+  userId: string;
+  gs1sk: string;
+  gs1pk: string;
+}
+
+interface KyashuResponse {
+  Count: number;
+  Items: KyashuItem[];
+  LastEvaluatedKey: {
+    pk: string;
+    sk: string;
+    userId: string;
+  };
+}
+
+interface CapUserTransaction extends TransactionPrettified {
+  canisterInfo: CanisterInfo & { canisterId: string };
+}
+
+export interface GetUserTransactionResponse {
+  total: number;
+  transactions: CapUserTransaction[];
+}
+
+const getTransactionCanister = (sk: string): string | undefined => sk?.split('#')?.pop()?.[0];
+
+
+export const getUserTransactions = async (
+  principalId: string
+): Promise<GetUserTransactionResponse>  => {
+  const url = `${KYASHU_URL}/cap/user/txns/${principalId}`;
+  try {
+    const response = await axios.get<any, AxiosResponse<KyashuResponse>>(url);
+    const canisterIds = [...new Set(response.data.Items.map(item => getTransactionCanister(item.sk)))].filter(value => value) as string[]
+    const canistersInfo = (await getMultipleCanisterInfo(canisterIds))
+      .reduce((acum, canisterInfo, idx) => ({ ...acum, [canisterIds[idx]]: { canisterId: canisterIds[idx], ...canisterInfo } }), {})
+    return {
+      total: response.data.Count,
+      transactions: response.data.Items.map(item => {
+        const canisterId = getTransactionCanister(item.sk)
+        return {
+          canisterInfo: canisterId ? canistersInfo[canisterId] : undefined,
+          ...prettifyCapTransactions(item.event)
+        }
+      }
+      ),
+    };
+  } catch (e) {
+    return {
+      total: 0,
+      transactions: [],
+    };
+  }
+};
+
+export default {};

--- a/src/utils/dfx/history/cap.ts
+++ b/src/utils/dfx/history/cap.ts
@@ -1,8 +1,13 @@
 /* eslint-disable camelcase */
 /* eslint-disable no-underscore-dangle */
 import axios, { AxiosResponse } from 'axios';
-import { prettifyCapTransactions, TransactionPrettified } from '@psychedelic/cap-js';
-import { CanisterInfo, getMultipleCanisterInfo } from '../../dab';
+import { Principal } from '@dfinity/principal';
+import {
+  prettifyCapTransactions,
+  TransactionPrettified,
+} from '@psychedelic/cap-js';
+import { getMultipleCanisterInfo } from '../../dab';
+import { InferredTransaction } from './rosetta';
 
 const KYASHU_URL = 'https://kyasshu.fleek.co';
 
@@ -27,40 +32,62 @@ interface KyashuResponse {
   LastEvaluatedKey: LastEvaluatedKey;
 }
 
-interface CapUserTransaction extends TransactionPrettified {
-  canisterInfo: CanisterInfo & { canisterId: string };
-}
-
 export interface GetUserTransactionResponse {
   total: number;
-  transactions: CapUserTransaction[];
+  transactions: InferredTransaction[];
   lastEvaluatedKey?: LastEvaluatedKey;
 }
 
-const getTransactionCanister = (sk: string): string | undefined => sk?.split('#')?.pop()?.[0];
+const getTransactionCanister = (sk: string): string | undefined =>
+  sk?.split('#')?.[1];
 
+const formatTransaction = (
+  transaction: TransactionPrettified,
+  sk: string
+): InferredTransaction => ({
+  hash: sk,
+  timestamp: transaction.time,
+  type: transaction.operation,
+  details: transaction.details,
+  caller: Principal.fromUint8Array((transaction.caller as any)._arr).toString(),
+});
 
-export const getUserTransactions = async (
+export const getCapTransactions = async (
   principalId: string,
-  lastEvaluatedKey?: string,
+  lastEvaluatedKey?: string
 ): Promise<GetUserTransactionResponse> => {
-  const url = `${KYASHU_URL}/cap/user/txns/${principalId}${lastEvaluatedKey ? `?LastEvaluatedKey=${lastEvaluatedKey}` : ''}`;
+  const url = `${KYASHU_URL}/cap/user/txns/${principalId}${
+    lastEvaluatedKey ? `?LastEvaluatedKey=${lastEvaluatedKey}` : ''
+  }`;
   try {
     const response = await axios.get<any, AxiosResponse<KyashuResponse>>(url);
-    const canisterIds = [...new Set(response.data.Items.map(item => getTransactionCanister(item.sk)))].filter(value => value) as string[]
-    const canistersInfo = (await getMultipleCanisterInfo(canisterIds))
-      .reduce((acum, canisterInfo, idx) => ({ ...acum, [canisterIds[idx]]: { canisterId: canisterIds[idx], ...canisterInfo } }), {})
+    const canisterIds = [
+      ...new Set(
+        response.data.Items.map(item => getTransactionCanister(item.sk))
+      ),
+    ].filter(value => value) as string[];
+    const canistersInfo = (await getMultipleCanisterInfo(canisterIds)).reduce(
+      (acum, canisterInfo, idx) => ({
+        ...acum,
+        [canisterIds[idx]]: { canisterId: canisterIds[idx], ...canisterInfo },
+      }),
+      {}
+    );
+    const transactions = response.data.Items.map(item => {
+      const canisterId = getTransactionCanister(item.sk);
+      const formattedTx = formatTransaction(
+        prettifyCapTransactions(item.event),
+        item.sk
+      );
+      return {
+        ...formattedTx,
+        canisterInfo: canisterId ? canistersInfo[canisterId] : undefined,
+      };
+    });
     return {
       total: response.data.Count,
       lastEvaluatedKey: response.data.LastEvaluatedKey,
-      transactions: response.data.Items.map(item => {
-        const canisterId = getTransactionCanister(item.sk)
-        return {
-          canisterInfo: canisterId ? canistersInfo[canisterId] : undefined,
-          ...prettifyCapTransactions(item.event)
-        }
-      }
-      ),
+      transactions,
     };
   } catch (e) {
     return {

--- a/src/utils/dfx/history/cap.ts
+++ b/src/utils/dfx/history/cap.ts
@@ -48,7 +48,7 @@ const formatTransaction = (
   hash: sk,
   timestamp: transaction.time,
   type: transaction.operation,
-  details: transaction.details,
+  details: { ...transaction.details, canisterId: getTransactionCanister(sk) },
   caller: Principal.fromUint8Array((transaction.caller as any)._arr).toString(),
 });
 

--- a/src/utils/dfx/history/rosetta.ts
+++ b/src/utils/dfx/history/rosetta.ts
@@ -1,6 +1,5 @@
 /* eslint-disable camelcase */
 /* eslint-disable @typescript-eslint/camelcase */
-
 import fetch from 'cross-fetch';
 import { ERRORS } from '../../../errors';
 import { NET_ID, ROSETTA_URL } from '../constants';
@@ -40,16 +39,7 @@ interface RosettaTransaction {
 
 export interface InferredTransaction {
   hash: string;
-  // from: string;
-  // to: string;
-  // amount?: bigint;
-  // currency?: Currency;
-  // fee?: {
-  //   amount: bigint;
-  //   currency: Currency;
-  // };
   timestamp: bigint;
-  // status: 'COMPLETED' | 'REVERTED' | 'PENDING';
   type: string;
   details?: { [key: string]: any };
   caller: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -355,6 +355,17 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@dfinity/agent@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@dfinity/agent/-/agent-0.10.1.tgz#6379b42977ca30a3718ee5b6f67f0d69c995aa21"
+  integrity sha512-VUHO5mveK0XX8b9xbfg5SThEGLhMAwkfejuwS5fzF9gqQVWqnIx5ISrbre8UvNNyuzM5v4/vZI+kpE2zL54rwg==
+  dependencies:
+    base64-arraybuffer "^0.2.0"
+    bignumber.js "^9.0.0"
+    borc "^2.1.1"
+    js-sha256 "0.9.0"
+    simple-cbor "^0.4.1"
+
 "@dfinity/agent@^0.9.3":
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/@dfinity/agent/-/agent-0.9.3.tgz#e49f07d6749e534c4c30aa2df2bba59e3fa9570f"
@@ -367,6 +378,11 @@
     buffer-pipe "^0.0.4"
     js-sha256 "0.9.0"
     simple-cbor "^0.4.1"
+
+"@dfinity/candid@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@dfinity/candid/-/candid-0.10.1.tgz#f93d7cdc3856a6d527f31c7112a0537ef70ba315"
+  integrity sha512-Z7C125quoAYafj+yK20KQKI/MkXgB9tgPkvtIk1Ec8eGXIU7OXOHSIknvJR6zXdE9eUc/veiD4+VDWK7I82sDw==
 
 "@dfinity/candid@^0.9.3":
   version "0.9.3"
@@ -385,6 +401,11 @@
     buffer "^6.0.3"
     buffer-pipe "0.0.4"
     tweetnacl "^1.0.1"
+
+"@dfinity/principal@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@dfinity/principal/-/principal-0.10.1.tgz#2472aa0eef8b46000394720ef40bbd4bd330c000"
+  integrity sha512-1/r726xwVlSsCc+Fl2szM+P9xNfsu5TItC56n/KRuhGEE9sN8NLnorxcNvpzoII0f99XBNCNMRJPUkWSZPLpbw==
 
 "@dfinity/principal@^0.9.3":
   version "0.9.3"
@@ -692,6 +713,17 @@
   integrity sha512-HCh0qPge1JCqTEw4s2ScnicEZd4Ro4/0VvdjpsfCiX6fuDV53fRZ2uqLTgxKGHrVoqOZnVrRZHyhFyEsFGs+zQ==
   dependencies:
     fancy-test "^1.4.3"
+
+"@psychedelic/cap-js@^0.0.5":
+  version "0.0.5"
+  resolved "https://npm.pkg.github.com/download/@psychedelic/cap-js/0.0.5/5623abd851cdf8c36d6a2c2dc961f0ba9b1b9ca4e5db4c0f25e56d5afbc85de4#2eb444e86b24098a8162f67d3f1c4734cc2a3fa0"
+  integrity sha512-2zaD6DKUMGk3veZvEEheVv5rPie7rh5q0BXY5qzthi56rd6Qo4xWQlyLNlGuyVzVRPWNbWGoF2zEBS2aBZci0Q==
+  dependencies:
+    "@dfinity/agent" "^0.10.1"
+    "@dfinity/candid" "^0.10.1"
+    "@dfinity/principal" "^0.10.1"
+    axios "^0.24.0"
+    cross-fetch "^3.1.4"
 
 "@psychedelic/dab-js@0.2.4":
   version "0.2.4"
@@ -1234,6 +1266,13 @@ axios@^0.21.1:
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
+
+axios@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
+  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
+  dependencies:
+    follow-redirects "^1.14.4"
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -2645,6 +2684,11 @@ follow-redirects@^1.14.0:
   version "1.14.4"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.4.tgz#838fdf48a8bbdd79e52ee51fb1c94e3ed98b9379"
   integrity sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==
+
+follow-redirects@^1.14.4:
+  version "1.14.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.5.tgz#f09a5848981d3c772b5392309778523f8d85c381"
+  integrity sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Summary
- Add `getCapTransactions` to fetch transaction history from CAP.
- Reformatted `InferredTransaction` and ICP and XTC histories to have a common interface with a `details` field.