### PR TITLE
refactor: keep old methods tokens

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
       'prettier/@typescript-eslint',
       'plugin:prettier/recommended',
       'eslint:recommended',
+      'react-app',
   ],
   parserOptions: {
       ecmaVersion: 6,

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test-console": "^1.1.0",
     "ts-jest": "^25.5.1",
     "ts-node": "^9.1.1",
-    "typescript": "^3.8.3"
+    "typescript": "^4.5"
   },
   "name": "@psychedelic/plug-controller",
   "version": "0.12.2",

--- a/src/PlugKeyRing/index.ts
+++ b/src/PlugKeyRing/index.ts
@@ -317,8 +317,8 @@ class PlugKeyRing {
 
   public getTokenInfo = async (
     canisterId: string,
+    standard = 'ext',
     subAccount?: number,
-    standard?: string
   ): Promise<{ token: StandardToken; amount: string }> => {
     this.checkUnlocked();
     const index = (subAccount ?? this.currentWalletId) || 0;

--- a/src/utils/dfx/actorFactory.ts
+++ b/src/utils/dfx/actorFactory.ts
@@ -4,7 +4,7 @@ import { Principal } from '@dfinity/principal';
 
 type ExtendedActorConstructor = new () => ActorSubclass;
 
-export type OldMethodsExtendedActor<T> = {
+export type BaseMethodsExtendedActor<T> = {
   [K in keyof T as `_${Uncapitalize<string & K>}`]: T[K];
 }
 

--- a/src/utils/dfx/actorFactory.ts
+++ b/src/utils/dfx/actorFactory.ts
@@ -4,6 +4,10 @@ import { Principal } from '@dfinity/principal';
 
 type ExtendedActorConstructor = new () => ActorSubclass;
 
+export type OldMethodsExtendedActor<T> = {
+  [K in keyof T as `_${Uncapitalize<string & K>}`]: T[K];
+}
+
 export const createExtendedActorClass = (
   agent: HttpAgent,
   methods,
@@ -13,6 +17,10 @@ export const createExtendedActorClass = (
   class ExtendedActor extends Actor.createActorClass(IDLFactory) {
     constructor() {
       super({ agent, canisterId });
+
+      Object.keys(this).forEach(methodName => {
+        this[`_${methodName}`] = this[methodName];
+      })
 
       Object.keys(methods).forEach(methodName => {
         this[methodName] = ((...args: unknown[]) =>

--- a/src/utils/dfx/ledger/methods.ts
+++ b/src/utils/dfx/ledger/methods.ts
@@ -5,6 +5,7 @@ import { ActorSubclass } from '@dfinity/agent';
 
 import LedgerService, { TimeStamp } from '../../../interfaces/ledger';
 import { Balance } from '../token/methods';
+import { OldMethodsExtendedActor } from '../actorFactory';
 
 const DECIMALS = 8;
 
@@ -21,13 +22,14 @@ interface SendICPArgs {
   opts?: SendOpts;
 }
 
-export interface LedgerServiceExtended extends LedgerService {
+type OldLedgerService = OldMethodsExtendedActor<LedgerService>
+export interface LedgerServiceExtended extends OldLedgerService {
   sendICP: (args_0: SendICPArgs) => Promise<string>;
   getBalance: (accountId: string) => Promise<Balance>;
 }
 
 const sendICP = async (
-  actor: ActorSubclass<LedgerService>,
+  actor: ActorSubclass<OldLedgerService>,
   args: SendICPArgs
 ): Promise<bigint> => {
   const { to, amount, opts } = args;
@@ -36,7 +38,7 @@ const sendICP = async (
     memo: BigInt(0),
   };
   const parsedAmount = BigInt(parseFloat(amount) * 10 ** DECIMALS);
-  return actor.send_dfx({
+  return actor._send_dfx({
     to,
     fee: { e8s: opts?.fee || defaultArgs.fee },
     amount: { e8s: parsedAmount },
@@ -47,10 +49,10 @@ const sendICP = async (
 };
 
 const getBalance = async (
-  actor: ActorSubclass<LedgerService>,
+  actor: ActorSubclass<OldLedgerService>,
   accountId: string
 ): Promise<Balance> => {
-  const balance = await actor.account_balance_dfx({ account: accountId });
+  const balance = await actor._account_balance_dfx({ account: accountId });
   return { value: balance.e8s.toString(), decimals: DECIMALS };
 };
 

--- a/src/utils/dfx/ledger/methods.ts
+++ b/src/utils/dfx/ledger/methods.ts
@@ -5,7 +5,7 @@ import { ActorSubclass } from '@dfinity/agent';
 
 import LedgerService, { TimeStamp } from '../../../interfaces/ledger';
 import { Balance } from '../token/methods';
-import { OldMethodsExtendedActor } from '../actorFactory';
+import { BaseMethodsExtendedActor } from '../actorFactory';
 
 const DECIMALS = 8;
 
@@ -22,14 +22,14 @@ interface SendICPArgs {
   opts?: SendOpts;
 }
 
-type OldLedgerService = OldMethodsExtendedActor<LedgerService>
-export interface LedgerServiceExtended extends OldLedgerService {
+type BaseLedgerService = BaseMethodsExtendedActor<LedgerService>
+export interface LedgerServiceExtended extends BaseLedgerService {
   sendICP: (args_0: SendICPArgs) => Promise<string>;
   getBalance: (accountId: string) => Promise<Balance>;
 }
 
 const sendICP = async (
-  actor: ActorSubclass<OldLedgerService>,
+  actor: ActorSubclass<BaseLedgerService>,
   args: SendICPArgs
 ): Promise<bigint> => {
   const { to, amount, opts } = args;
@@ -49,7 +49,7 @@ const sendICP = async (
 };
 
 const getBalance = async (
-  actor: ActorSubclass<OldLedgerService>,
+  actor: ActorSubclass<BaseLedgerService>,
   accountId: string
 ): Promise<Balance> => {
   const balance = await actor._account_balance_dfx({ account: accountId });

--- a/src/utils/dfx/nns_uid/methods.ts
+++ b/src/utils/dfx/nns_uid/methods.ts
@@ -6,15 +6,15 @@ import { ActorSubclass } from '@dfinity/agent';
 import NNSService, {
   GetTransactionsResponse,
 } from '../../../interfaces/nns_uid';
-import { OldMethodsExtendedActor } from '../actorFactory';
+import { BaseMethodsExtendedActor } from '../actorFactory';
 
-type OldNNSService = OldMethodsExtendedActor<NNSService>
-export interface NNSServiceExtended extends OldNNSService {
+type BaseNNSService = BaseMethodsExtendedActor<NNSService>
+export interface NNSServiceExtended extends BaseNNSService {
   getTransactions: (accountId: string) => Promise<GetTransactionsResponse>;
 }
 
 const getTransactions = (
-  actor: ActorSubclass<OldNNSService>,
+  actor: ActorSubclass<BaseNNSService>,
   accountId: string
 ): Promise<GetTransactionsResponse> => {
   return actor._get_transactions({

--- a/src/utils/dfx/nns_uid/methods.ts
+++ b/src/utils/dfx/nns_uid/methods.ts
@@ -6,16 +6,18 @@ import { ActorSubclass } from '@dfinity/agent';
 import NNSService, {
   GetTransactionsResponse,
 } from '../../../interfaces/nns_uid';
+import { OldMethodsExtendedActor } from '../actorFactory';
 
-export interface NNSServiceExtended extends NNSService {
+type OldNNSService = OldMethodsExtendedActor<NNSService>
+export interface NNSServiceExtended extends OldNNSService {
   getTransactions: (accountId: string) => Promise<GetTransactionsResponse>;
 }
 
 const getTransactions = (
-  actor: ActorSubclass<NNSService>,
+  actor: ActorSubclass<OldNNSService>,
   accountId: string
 ): Promise<GetTransactionsResponse> => {
-  return actor.get_transactions({
+  return actor._get_transactions({
     account_identifier: accountId,
     page_size: 20,
     offset: 0,

--- a/src/utils/dfx/token/dip20Methods.ts
+++ b/src/utils/dfx/token/dip20Methods.ts
@@ -13,11 +13,14 @@ import {
   SendParams,
   SendResponse,
 } from './methods';
+import { OldMethodsExtendedActor } from '../actorFactory';
+
+type OldDip20Service = OldMethodsExtendedActor<Dip20Service>;
 
 const getMetadata = async (
-  actor: ActorSubclass<Dip20Service>
+  actor: ActorSubclass<OldDip20Service>
 ): Promise<Metadata> => {
-  const metadataResult = await actor.getMetadata();
+  const metadataResult = await actor._getMetadata();
   return {
     fungible: {
       symbol: metadataResult.symbol,
@@ -28,14 +31,14 @@ const getMetadata = async (
 };
 
 const send = async (
-  actor: ActorSubclass<Dip20Service>,
+  actor: ActorSubclass<OldDip20Service>,
   { to, amount }: SendParams
 ): Promise<SendResponse> => {
   const decimals = getDecimals(await getMetadata(actor));
 
   const parsedAmount = parseAmountToSend(amount, decimals);
 
-  const transferResult = await actor.transfer(
+  const transferResult = await actor._transfer(
     Principal.fromText(to),
     parsedAmount
   );
@@ -47,16 +50,16 @@ const send = async (
 };
 
 const getBalance = async (
-  actor: ActorSubclass<Dip20Service>,
+  actor: ActorSubclass<OldDip20Service>,
   user: Principal
 ): Promise<Balance> => {
   const decimals = getDecimals(await getMetadata(actor));
-  const value = (await actor.balanceOf(user)).toString();
+  const value = (await actor._balanceOf(user)).toString();
   return { value, decimals };
 };
 
 const burnXTC = async (
-  _actor: ActorSubclass<Dip20Service>,
+  _actor: ActorSubclass<OldDip20Service>,
   _params: BurnParams
 ) => {
   throw new Error('BURN NOT SUPPORTED');

--- a/src/utils/dfx/token/dip20Methods.ts
+++ b/src/utils/dfx/token/dip20Methods.ts
@@ -13,12 +13,12 @@ import {
   SendParams,
   SendResponse,
 } from './methods';
-import { OldMethodsExtendedActor } from '../actorFactory';
+import { BaseMethodsExtendedActor } from '../actorFactory';
 
-type OldDip20Service = OldMethodsExtendedActor<Dip20Service>;
+type BaseDip20Service = BaseMethodsExtendedActor<Dip20Service>;
 
 const getMetadata = async (
-  actor: ActorSubclass<OldDip20Service>
+  actor: ActorSubclass<BaseDip20Service>
 ): Promise<Metadata> => {
   const metadataResult = await actor._getMetadata();
   return {
@@ -31,7 +31,7 @@ const getMetadata = async (
 };
 
 const send = async (
-  actor: ActorSubclass<OldDip20Service>,
+  actor: ActorSubclass<BaseDip20Service>,
   { to, amount }: SendParams
 ): Promise<SendResponse> => {
   const decimals = getDecimals(await getMetadata(actor));
@@ -50,7 +50,7 @@ const send = async (
 };
 
 const getBalance = async (
-  actor: ActorSubclass<OldDip20Service>,
+  actor: ActorSubclass<BaseDip20Service>,
   user: Principal
 ): Promise<Balance> => {
   const decimals = getDecimals(await getMetadata(actor));
@@ -59,7 +59,7 @@ const getBalance = async (
 };
 
 const burnXTC = async (
-  _actor: ActorSubclass<OldDip20Service>,
+  _actor: ActorSubclass<BaseDip20Service>,
   _params: BurnParams
 ) => {
   throw new Error('BURN NOT SUPPORTED');

--- a/src/utils/dfx/token/extMethods.ts
+++ b/src/utils/dfx/token/extMethods.ts
@@ -3,7 +3,7 @@ import { Principal } from '@dfinity/principal';
 import { ERRORS } from '../../../errors';
 
 import ExtService, { Metadata } from '../../../interfaces/ext';
-import { OldMethodsExtendedActor } from '../actorFactory';
+import { BaseMethodsExtendedActor } from '../actorFactory';
 import {
   Balance,
   BurnParams,
@@ -15,10 +15,10 @@ import {
   TokenServiceExtended,
 } from './methods';
 
-type OldExtService = OldMethodsExtendedActor<ExtService>
+type BaseExtService = BaseMethodsExtendedActor<ExtService>
 
 const getMetadata = async (
-  actor: ActorSubclass<OldExtService>
+  actor: ActorSubclass<BaseExtService>
 ): Promise<Metadata> => {
   actor._balance
   const token = Actor.canisterIdOf(actor).toText();
@@ -34,7 +34,7 @@ const getMetadata = async (
 };
 
 const send = async (
-  actor: ActorSubclass<OldExtService>,
+  actor: ActorSubclass<BaseExtService>,
   { to, from, amount }: SendParams
 ): Promise<SendResponse> => {
   const dummyMemmo = new Array(32).fill(0);
@@ -62,7 +62,7 @@ const send = async (
 };
 
 const getBalance = async (
-  actor: ActorSubclass<OldExtService>,
+  actor: ActorSubclass<BaseExtService>,
   user: Principal
 ): Promise<Balance> => {
   const token = Actor.canisterIdOf(actor).toText();
@@ -81,7 +81,7 @@ const getBalance = async (
 };
 
 const burnXTC = async (
-  _actor: ActorSubclass<OldExtService>,
+  _actor: ActorSubclass<BaseExtService>,
   _params: BurnParams
 ) => {
   throw new Error('BURN NOT SUPPORTED');

--- a/src/utils/dfx/token/extMethods.ts
+++ b/src/utils/dfx/token/extMethods.ts
@@ -3,6 +3,7 @@ import { Principal } from '@dfinity/principal';
 import { ERRORS } from '../../../errors';
 
 import ExtService, { Metadata } from '../../../interfaces/ext';
+import { OldMethodsExtendedActor } from '../actorFactory';
 import {
   Balance,
   BurnParams,
@@ -11,17 +12,21 @@ import {
   SendParams,
   SendResponse,
   parseAmountToSend,
+  TokenServiceExtended,
 } from './methods';
 
+type OldExtService = OldMethodsExtendedActor<ExtService>
+
 const getMetadata = async (
-  actor: ActorSubclass<ExtService>
+  actor: ActorSubclass<OldExtService>
 ): Promise<Metadata> => {
+  actor._balance
   const token = Actor.canisterIdOf(actor).toText();
 
-  const extensions = await actor.extensions();
+  const extensions = await actor._extensions();
   if (!extensions.includes('@ext/common'))
     throw new Error(ERRORS.TOKEN_NOT_SUPPORT_METADATA);
-  const metadataResult = await actor.metadata(token);
+  const metadataResult = await actor._metadata(token);
 
   if ('ok' in metadataResult) return metadataResult.ok;
 
@@ -29,7 +34,7 @@ const getMetadata = async (
 };
 
 const send = async (
-  actor: ActorSubclass<ExtService>,
+  actor: ActorSubclass<OldExtService>,
   { to, from, amount }: SendParams
 ): Promise<SendResponse> => {
   const dummyMemmo = new Array(32).fill(0);
@@ -49,7 +54,7 @@ const send = async (
     fee: BigInt(1),
   };
 
-  const transferResult = await actor.transfer(data);
+  const transferResult = await actor._transfer(data);
 
   if ('ok' in transferResult) return { amount: transferResult.ok.toString() };
 
@@ -57,12 +62,12 @@ const send = async (
 };
 
 const getBalance = async (
-  actor: ActorSubclass<ExtService>,
+  actor: ActorSubclass<OldExtService>,
   user: Principal
 ): Promise<Balance> => {
   const token = Actor.canisterIdOf(actor).toText();
 
-  const balanceResult = await actor.balance({
+  const balanceResult = await actor._balance({
     token,
     user: { principal: user },
   });
@@ -76,7 +81,7 @@ const getBalance = async (
 };
 
 const burnXTC = async (
-  _actor: ActorSubclass<ExtService>,
+  _actor: ActorSubclass<OldExtService>,
   _params: BurnParams
 ) => {
   throw new Error('BURN NOT SUPPORTED');

--- a/src/utils/dfx/token/index.ts
+++ b/src/utils/dfx/token/index.ts
@@ -34,11 +34,11 @@ const getIdl = (standard: string): IDL.InterfaceFactory => {
   return idl;
 };
 
-export const createTokenActor = async (
+export const createTokenActor = async <T>(
   canisterId: string | Principal,
   agent: HttpAgent,
   standard: string
-): Promise<ActorSubclass<TokenServiceExtended>> => {
+): Promise<ActorSubclass<TokenServiceExtended<T>>> => {
   const idl = getIdl(standard);
 
   const actor = (new (createExtendedActorClass(
@@ -46,7 +46,7 @@ export const createTokenActor = async (
     getMethods(standard),
     canisterId,
     idl
-  ))() as unknown) as ActorSubclass<TokenServiceExtended>;
+  ))() as unknown) as ActorSubclass<TokenServiceExtended<any>>;
   return actor;
 };
 

--- a/src/utils/dfx/token/methods.ts
+++ b/src/utils/dfx/token/methods.ts
@@ -3,6 +3,7 @@ import { Principal } from '@dfinity/principal';
 
 import { Metadata } from '../../../interfaces/ext';
 import { BurnResult } from '../../../interfaces/xtc';
+import { OldMethodsExtendedActor } from '../actorFactory';
 
 export type SendResponse =
   | { height: string }
@@ -24,12 +25,15 @@ export interface Balance {
   value: string;
   decimals: number;
 }
-export interface TokenServiceExtended {
+
+interface AddedMehtodsToken {
   send: ({ to, from, amount }: SendParams) => Promise<SendResponse>;
   getMetadata: () => Promise<Metadata>;
   getBalance: (user: Principal) => Promise<Balance>;
   burnXTC: ({ to, amount }: BurnParams) => Promise<BurnResult>;
 }
+
+export type TokenServiceExtended<T> = OldMethodsExtendedActor<T> & AddedMehtodsToken
 
 export interface InternalTokenMethods {
   send: (

--- a/src/utils/dfx/token/methods.ts
+++ b/src/utils/dfx/token/methods.ts
@@ -3,7 +3,7 @@ import { Principal } from '@dfinity/principal';
 
 import { Metadata } from '../../../interfaces/ext';
 import { BurnResult } from '../../../interfaces/xtc';
-import { OldMethodsExtendedActor } from '../actorFactory';
+import { BaseMethodsExtendedActor } from '../actorFactory';
 
 export type SendResponse =
   | { height: string }
@@ -33,7 +33,7 @@ interface AddedMehtodsToken {
   burnXTC: ({ to, amount }: BurnParams) => Promise<BurnResult>;
 }
 
-export type TokenServiceExtended<T> = OldMethodsExtendedActor<T> & AddedMehtodsToken
+export type TokenServiceExtended<T> = BaseMethodsExtendedActor<T> & AddedMehtodsToken
 
 export interface InternalTokenMethods {
   send: (

--- a/src/utils/dfx/token/xtcMethods.ts
+++ b/src/utils/dfx/token/xtcMethods.ts
@@ -13,12 +13,12 @@ import {
   SendParams,
   SendResponse,
 } from './methods';
-import { OldMethodsExtendedActor } from '../actorFactory';
+import { BaseMethodsExtendedActor } from '../actorFactory';
 
-type OldXtcService = OldMethodsExtendedActor<XtcService>
+type BaseXtcService = BaseMethodsExtendedActor<XtcService>
 
 const getMetadata = async (
-  actor: ActorSubclass<OldXtcService>
+  actor: ActorSubclass<BaseXtcService>
 ): Promise<Metadata> => {
   const metadataResult = await actor._meta();
   return {
@@ -31,7 +31,7 @@ const getMetadata = async (
 };
 
 const send = async (
-  actor: ActorSubclass<OldXtcService>,
+  actor: ActorSubclass<BaseXtcService>,
   { to, amount }: SendParams
 ): Promise<SendResponse> => {
   const decimals = getDecimals(await getMetadata(actor));
@@ -49,7 +49,7 @@ const send = async (
 };
 
 const getBalance = async (
-  actor: ActorSubclass<OldXtcService>,
+  actor: ActorSubclass<BaseXtcService>,
   user: Principal
 ): Promise<Balance> => {
   const decimals = getDecimals(await getMetadata(actor));
@@ -58,7 +58,7 @@ const getBalance = async (
 };
 
 const burnXTC = async (
-  actor: ActorSubclass<OldXtcService>,
+  actor: ActorSubclass<BaseXtcService>,
   { to, amount }: BurnParams
 ): Promise<BurnResult> => {
   const decimals = getDecimals(await getMetadata(actor));

--- a/src/utils/dfx/token/xtcMethods.ts
+++ b/src/utils/dfx/token/xtcMethods.ts
@@ -13,11 +13,14 @@ import {
   SendParams,
   SendResponse,
 } from './methods';
+import { OldMethodsExtendedActor } from '../actorFactory';
+
+type OldXtcService = OldMethodsExtendedActor<XtcService>
 
 const getMetadata = async (
-  actor: ActorSubclass<XtcService>
+  actor: ActorSubclass<OldXtcService>
 ): Promise<Metadata> => {
-  const metadataResult = await actor.meta();
+  const metadataResult = await actor._meta();
   return {
     fungible: {
       symbol: metadataResult.symbol,
@@ -28,13 +31,13 @@ const getMetadata = async (
 };
 
 const send = async (
-  actor: ActorSubclass<XtcService>,
+  actor: ActorSubclass<OldXtcService>,
   { to, amount }: SendParams
 ): Promise<SendResponse> => {
   const decimals = getDecimals(await getMetadata(actor));
   const parsedAmount = parseAmountToSend(amount, decimals);
 
-  const transferResult = await actor.transferErc20(
+  const transferResult = await actor._transferErc20(
     Principal.fromText(to),
     parsedAmount
   );
@@ -46,21 +49,21 @@ const send = async (
 };
 
 const getBalance = async (
-  actor: ActorSubclass<XtcService>,
+  actor: ActorSubclass<OldXtcService>,
   user: Principal
 ): Promise<Balance> => {
   const decimals = getDecimals(await getMetadata(actor));
-  const value = (await actor.balance([user])).toString();
+  const value = (await actor._balance([user])).toString();
   return { value, decimals };
 };
 
 const burnXTC = async (
-  actor: ActorSubclass<XtcService>,
+  actor: ActorSubclass<OldXtcService>,
   { to, amount }: BurnParams
 ): Promise<BurnResult> => {
   const decimals = getDecimals(await getMetadata(actor));
   const parsedAmount = parseAmountToSend(amount, decimals);
-  return actor.burn({ canister_id: to, amount: parsedAmount });
+  return actor._burn({ canister_id: to, amount: parsedAmount });
 };
 
 export default {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5785,10 +5785,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^3.8.3:
-  version "3.9.10"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
-  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
+typescript@^4.5:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
+  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
# refactor: keep old methods tokens

## Summary

Now ExtendedActor have available every original method with this name underscored for example `_${method}`