### PR TITLE
fix: specify elliptical curve in pem file

### DIFF
--- a/src/utils/crypto/secpk256k1/identity.ts
+++ b/src/utils/crypto/secpk256k1/identity.ts
@@ -15,7 +15,10 @@ declare type PublicKeyHex = string;
 declare type SecretKeyHex = string;
 export declare type JsonableSecp256k1Identity = [PublicKeyHex, SecretKeyHex];
 
-const PEM_BEGIN = '-----BEGIN EC PRIVATE KEY-----';
+const PEM_BEGIN = `-----BEGIN EC PARAMETERS-----
+BgUrgQQACg==
+-----END EC PARAMETERS-----
+-----BEGIN EC PRIVATE KEY-----`;
 
 const PEM_END = '-----END EC PRIVATE KEY-----';
 

--- a/src/utils/crypto/secpk256k1/identity.ts
+++ b/src/utils/crypto/secpk256k1/identity.ts
@@ -19,10 +19,9 @@ const PEM_BEGIN = '-----BEGIN EC PRIVATE KEY-----';
 
 const PEM_END = '-----END EC PRIVATE KEY-----';
 
-const PRIV_KEY_INIT =
-  '308184020100301006072a8648ce3d020106052b8104000a046d306b0201010420';
+const PRIV_KEY_INIT = '30740201010420';
 
-const KEY_SEPARATOR = 'a144034200';
+const KEY_SEPARATOR = 'a00706052b8104000aa144034200';
 
 class Secp256k1KeyIdentity extends SignIdentity {
   public static fromParsedJson(obj: [string, string]): Secp256k1KeyIdentity {

--- a/src/utils/crypto/secpk256k1/identity.ts
+++ b/src/utils/crypto/secpk256k1/identity.ts
@@ -15,9 +15,9 @@ declare type PublicKeyHex = string;
 declare type SecretKeyHex = string;
 export declare type JsonableSecp256k1Identity = [PublicKeyHex, SecretKeyHex];
 
-const PEM_BEGIN = '-----BEGIN PRIVATE KEY-----';
+const PEM_BEGIN = '-----BEGIN EC PRIVATE KEY-----';
 
-const PEM_END = '-----END PRIVATE KEY-----';
+const PEM_END = '-----END EC PRIVATE KEY-----';
 
 const PRIV_KEY_INIT =
   '308184020100301006072a8648ce3d020106052b8104000a046d306b0201010420';


### PR DESCRIPTION
this fixes `dfx identity import` on a plug wallets exported pem file, by aligning to the format followed in https://github.com/dfinity/quill/blob/master/src/lib/mod.rs#L266-L312

tested with dfx 0.9.2 and 0.10.0

# how?
- pem is an EC private key, specify that
- use proper prefix and separator
- added optional EC PARAMS

# example
identity: `testx-e77hz-sdzqx-zxey4-42uhc-w3yyz-mdvdx-lh4k3-xlpp7-fnndb-zae`
seed: `tragic high razor pattern casual cute bring misery hand peasant zero width`

exported quill pem (from dfinity, this is correct):
```
-----BEGIN EC PARAMETERS-----
BgUrgQQACg==
-----END EC PARAMETERS-----
-----BEGIN EC PRIVATE KEY-----
MHQCAQEEIIg5ea3ya6VZ/cdD67vyT6bwAXHGOP/i2VtfRQhjCE1loAcGBSuBBAAK
oUQDQgAES4w8nS2jhHiCTOn+FjvFF00/6MZ31a01fklZxURepr19f8bfUFkWi5TH
JwWMz1ehQqo3gvXVInttO+MmUzlf1Q==
-----END EC PRIVATE KEY-----
```

exported plug-controller pem (latest from this branch):
```
-----BEGIN EC PARAMETERS-----
BgUrgQQACg==
-----END EC PARAMETERS-----
-----BEGIN EC PRIVATE KEY-----
MHQCAQEEIIg5ea3ya6VZ/cdD67vyT6bwAXHGOP/i2VtfRQhjCE1loAcGBSuBBAAKoUQDQgAES4w8nS2jhHiCTOn+FjvFF00/6MZ31a01fklZxURepr19f8bfUFkWi5THJwWMz1ehQqo3gvXVInttO+MmUzlf1Q==
-----END EC PRIVATE KEY-----
```