### PR TITLE
Fix: DIP20 token fees

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@dfinity/identity": "0.9.3",
     "@dfinity/principal": "0.9.3",
     "@psychedelic/cap-js": "0.0.7",
-    "@psychedelic/dab-js": "1.4.6",
+    "@psychedelic/dab-js": "1.4.8",
     "@types/secp256k1": "^4.0.3",
     "axios": "^0.21.1",
     "babel-jest": "^25.5.1",
@@ -58,7 +58,7 @@
     "typescript": "^4.5"
   },
   "name": "@psychedelic/plug-controller",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Internet Computer Plug wallet's controller",
   "main": "dist/index.js",
   "scripts": {

--- a/src/constants/version.ts
+++ b/src/constants/version.ts
@@ -1,1 +1,1 @@
-export const PLUG_CONTROLLER_VERSION = "0.20.0";
+export const PLUG_CONTROLLER_VERSION = "0.20.1";

--- a/yarn.lock
+++ b/yarn.lock
@@ -799,10 +799,10 @@
     axios "^0.24.0"
     cross-fetch "^3.1.4"
 
-"@psychedelic/dab-js@1.4.6":
-  version "1.4.6"
-  resolved "https://npm.pkg.github.com/download/@Psychedelic/dab-js/1.4.6/8c06156d4c51634e2a35a837e3b89d18f246ce0e#8c06156d4c51634e2a35a837e3b89d18f246ce0e"
-  integrity sha512-p5MhoUikpqb+osqjg4dthiKFYt9X4EMKPOBbe6OD20iOxvmTIqQ3dqejwXSJO28ohFCnZseRG+UQsfoz+6jhTw==
+"@psychedelic/dab-js@1.4.8":
+  version "1.4.8"
+  resolved "https://npm.pkg.github.com/download/@Psychedelic/dab-js/1.4.8/42046f00e879a9eeec3aa19ad09cd55f4440b57c#42046f00e879a9eeec3aa19ad09cd55f4440b57c"
+  integrity sha512-keCVLyVz43A94cwlTo8MdxpfMl3ku8B09EXZNK6JPsis9iJ1OB/NIWNNviQSMMWbsh6d3nYKIRnjATGvf+CQxw==
   dependencies:
     "@dfinity/agent" "0.9.3"
     "@dfinity/candid" "0.9.3"


### PR DESCRIPTION
## Summary
- Installed dab-js 1.4.8 with dip20 fee fix. Fixes issues when trying to send the maximum amount of a dip20 token