### PR TITLE
Fix: Token fee info, activity item icns replacement

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@dfinity/identity": "0.9.3",
     "@dfinity/principal": "0.9.3",
     "@psychedelic/cap-js": "0.0.7",
-    "@psychedelic/dab-js": "1.4.10",
+    "@psychedelic/dab-js": "1.4.11",
     "@types/secp256k1": "^4.0.3",
     "axios": "^0.21.1",
     "babel-jest": "^25.5.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@dfinity/identity": "0.9.3",
     "@dfinity/principal": "0.9.3",
     "@psychedelic/cap-js": "0.0.7",
-    "@psychedelic/dab-js": "1.4.8",
+    "@psychedelic/dab-js": "1.4.10",
     "@types/secp256k1": "^4.0.3",
     "axios": "^0.21.1",
     "babel-jest": "^25.5.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@dfinity/identity": "0.9.3",
     "@dfinity/principal": "0.9.3",
     "@psychedelic/cap-js": "0.0.7",
-    "@psychedelic/dab-js": "1.4.11",
+    "@psychedelic/dab-js": "1.4.10",
     "@types/secp256k1": "^4.0.3",
     "axios": "^0.21.1",
     "babel-jest": "^25.5.1",
@@ -58,7 +58,7 @@
     "typescript": "^4.5"
   },
   "name": "@psychedelic/plug-controller",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Internet Computer Plug wallet's controller",
   "main": "dist/index.js",
   "scripts": {

--- a/src/PlugWallet/index.ts
+++ b/src/PlugWallet/index.ts
@@ -12,6 +12,7 @@ import {
   addAddress,
   removeAddress,
   getAllUserNFTs,
+  FungibleMetadata,
 } from '@psychedelic/dab-js';
 import randomColor from 'random-color';
 
@@ -307,9 +308,13 @@ class PlugWallet {
       });
 
       const balance = await tokenActor.getBalance(this.identity.getPrincipal());
+      const tokenMetadata = await tokenActor.getMetadata() as FungibleMetadata;
       return {
         amount: balance.value,
-        token,
+        token: {
+          ...token,
+          ...(tokenMetadata?.fungible || {}),
+        },
       };
     } catch (e) {
       console.warn('Get Balance error:', e);

--- a/src/utils/dfx/icns/utils.ts
+++ b/src/utils/dfx/icns/utils.ts
@@ -7,7 +7,8 @@ export const getMappingValue = (pid: string, mappings: ICNSMapping) => ({ princi
 
 export const replacePrincipalsForICNS = (tx: InferredTransaction, mappings: ICNSMapping): InferredTransaction => {
   const parsedTx = { ...tx };
-  const { from, to } = parsedTx?.details || {};
+  const { from: detailFrom, to } = parsedTx?.details || {};
+  const from = detailFrom || parsedTx?.caller;
   parsedTx.details = {
     ...parsedTx.details,
     from: getMappingValue(from, mappings),

--- a/yarn.lock
+++ b/yarn.lock
@@ -799,10 +799,10 @@
     axios "^0.24.0"
     cross-fetch "^3.1.4"
 
-"@psychedelic/dab-js@1.4.8":
-  version "1.4.8"
-  resolved "https://npm.pkg.github.com/download/@Psychedelic/dab-js/1.4.8/42046f00e879a9eeec3aa19ad09cd55f4440b57c#42046f00e879a9eeec3aa19ad09cd55f4440b57c"
-  integrity sha512-keCVLyVz43A94cwlTo8MdxpfMl3ku8B09EXZNK6JPsis9iJ1OB/NIWNNviQSMMWbsh6d3nYKIRnjATGvf+CQxw==
+"@psychedelic/dab-js@1.4.10":
+  version "1.4.10"
+  resolved "https://npm.pkg.github.com/download/@Psychedelic/dab-js/1.4.10/ab2728aa672012b6889bbfc2730e63149517e965#ab2728aa672012b6889bbfc2730e63149517e965"
+  integrity sha512-OBVif7y1qAk4ZPeB7bEeQGbDgUuNpwndGU86N8dNsoAmrgrHpNb47DGHnH9Rs6KG7fPMBnNed15BUBzCRVKR2Q==
   dependencies:
     "@dfinity/agent" "0.9.3"
     "@dfinity/candid" "0.9.3"


### PR DESCRIPTION
## Summary
- Serialize token metadata into `getTokenBalance` calls. 
- Use dab-js v 1.4.10 with icp-like fee fixes
- Add caller as a backup in case activity items do not have a from field