### PR TITLE
Fix: trim NFT collections

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "typescript": "^4.5"
   },
   "name": "@psychedelic/plug-controller",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Internet Computer Plug wallet's controller",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "typescript": "^4.5"
   },
   "name": "@psychedelic/plug-controller",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "description": "Internet Computer Plug wallet's controller",
   "main": "dist/index.js",
   "scripts": {

--- a/src/PlugKeyRing/index.ts
+++ b/src/PlugKeyRing/index.ts
@@ -4,25 +4,27 @@ import { BinaryBlob } from '@dfinity/candid';
 
 import {
   NFTDetails,
-  NFTCollection,
   TokenInterfaces,
 } from '@psychedelic/dab-js';
 import JsonBigInt from 'json-bigint';
 import { v4 as uuid } from "uuid";
 
-import { KeyringStorage, StorageData } from '../interfaces/storage';
-import { PlugStateStorage, PlugStateInstance } from '../interfaces/plug_keyring';
-import { TokenBalance, StandardToken } from '../interfaces/token';
-import { GetTransactionsResponse } from '../interfaces/transactions';
-import { ERRORS } from '../errors';
 import PlugWallet from '../PlugWallet';
-import { createAccount } from '../utils/account';
-import Storage from '../utils/storage';
-import { recursiveParseBigint } from '../utils/object';
-import { handleStorageUpdate } from '../utils/storage/utils';
-import { getVersion } from '../utils/version';
+import { PlugStateStorage, PlugStateInstance } from '../interfaces/plug_keyring';
+import { GetTransactionsResponse } from '../interfaces/transactions';
+import { KeyringStorage, StorageData } from '../interfaces/storage';
+import { TokenBalance, StandardToken } from '../interfaces/token';
+import { WalletNFTCollection } from '../interfaces/plug_wallet';
 import { Address } from '../interfaces/contact_registry';
+import { ERRORS } from '../errors';
+import { IdentityFactory } from './../utils/identity/identityFactory'
+import { handleStorageUpdate } from '../utils/storage/utils';
+import { createAccountFromMnemonic } from '../utils/account';
+import { recursiveParseBigint } from '../utils/object';
 import { Types } from '../utils/account/constants';
+import { createAccount } from '../utils/account';
+import { getVersion } from '../utils/version';
+import Storage from '../utils/storage';
 
 import NetworkModule, { NetworkModuleParams } from './modules/NetworkModule';
 import {
@@ -33,8 +35,6 @@ import {
   ImportMnemonicOptions,
 } from './interfaces';
 import { WALLET_METHODS } from './constants';
-import { createAccountFromMnemonic } from '../utils/account';
-import { IdentityFactory } from './../utils/identity/identityFactory'
 
 class PlugKeyRing {
   // state
@@ -52,8 +52,8 @@ class PlugKeyRing {
 
   // wallet methods
   public getBalances: (args?: { subaccount?: string }) => Promise<Array<TokenBalance>>;
-  public getNFTs: (args?: { subaccount?: string, refresh?: boolean }) => Promise<NFTCollection[] | null>;
-  public transferNFT: (args: { subaccount?: string; token: NFTDetails; to: string; standard: string; }) => Promise<NFTCollection[]>;
+  public getNFTs: (args?: { subaccount?: string, refresh?: boolean }) => Promise<WalletNFTCollection[] | null>;
+  public transferNFT: (args: { subaccount?: string; token: NFTDetails; to: string; standard: string; }) => Promise<WalletNFTCollection[]>;
   public burnXTC: (args?: { to: string; amount: string; subaccount: string; }) => Promise<TokenInterfaces.BurnResult>;
   public registerToken: (args: { canisterId: string; standard?: string; subaccount?: string; logo?: string; }) => Promise<Array<TokenBalance>>;
   public removeToken: (args: { canisterId: string; subaccount?: string; }) => Promise<Array<TokenBalance>>;

--- a/src/PlugWallet/index.ts
+++ b/src/PlugWallet/index.ts
@@ -16,6 +16,7 @@ import {
 } from '@psychedelic/dab-js';
 import randomColor from 'random-color';
 
+
 import { ERRORS } from '../errors';
 import { validateCanisterId, validatePrincipalId } from '../PlugKeyRing/utils';
 import { createAgent } from '../utils/dfx';
@@ -33,6 +34,7 @@ import {
   Assets,
   ICNSData,
   PlugWalletArgs,
+  WalletNFTCollection,
 } from '../interfaces/plug_wallet';
 import { StandardToken, TokenBalance } from '../interfaces/token';
 import { GetTransactionsResponse } from '../interfaces/transactions';
@@ -71,9 +73,9 @@ class PlugWallet {
 
   icnsData: ICNSData;
 
-  collections: Array<NFTCollection>;
+  collections: Array<WalletNFTCollection>;
   
-  customCollections: Array<NFTCollection>;
+  customCollections: Array<WalletNFTCollection>;
 
   contacts: Array<Address>;
 
@@ -144,21 +146,31 @@ class PlugWallet {
     this.icon = val;
   }
 
-  private nativeGetNFTs = async () => {
+  private populateAndTrimNFTs = async (collections: NFTCollection[]): Promise<WalletNFTCollection[]> => {
     const icnsAdapter = new ICNSAdapter(this.agent);
+    const collectionWithTokens = await getTokensFromCollections(this.network.registeredNFTS, this.principal, this.agent);
+    const icnsCollection = await icnsAdapter.getICNSCollection();
+    const unique = uniqueTokens([...collections, icnsCollection, ...collectionWithTokens]) as WalletNFTCollection[]
+    const simplifiedCollections = unique.map((collection: NFTCollection): WalletNFTCollection => ({
+      ...collection,
+      tokens: collection.tokens.map((token) => ({
+          index: token.index,
+          url: token.url,
+          canister: token.canister,
+          standard: token.standard,
+      })),
+    }));
+    const completeCollections = simplifiedCollections.filter((collection) => collection.tokens.length > 0);
+    return completeCollections;
+  }
+
+  private nativeGetNFTs = async () => {
     try {
-      this.collections = await getAllUserNFTs({
+      const collections = await getAllUserNFTs({
         user: this.principal,
         agent: this.agent,
       });
-      const customNfts = this.network.registeredNFTS;
-      
-      const collectionWithTokens = await getTokensFromCollections(customNfts, this.principal, this.agent);
-      
-      const icnsCollection = await icnsAdapter.getICNSCollection();
-
-      this.collections = uniqueTokens([...this.collections, icnsCollection, ...collectionWithTokens]) as NFTCollection[];
-
+      this.collections = await this.populateAndTrimNFTs(collections)
       return this.collections;
     } catch (e) {
       console.warn('Error when trying to fetch NFTs natively from the IC', e);
@@ -170,25 +182,14 @@ class PlugWallet {
   // TODO: Make generic when standard is adopted. Just supports ICPunks rn.
   public getNFTs = async (args?: {
     refresh?: boolean;
-  }): Promise<NFTCollection[] | null> => {
+  }): Promise<WalletNFTCollection[] | null> => {
     if (this.network.isCustom) return [];
     try {
-      const icnsAdapter = new ICNSAdapter(this.agent);
-      this.collections = await getCachedUserNFTs({
+      const collections = await getCachedUserNFTs({
         userPID: this.principal,
         refresh: args?.refresh,
       });
-
-      const customNfts = this.network.registeredNFTS;
-      
-      const collectionWithTokens = await getTokensFromCollections(customNfts, this.principal, this.agent);
-
-      const icnsCollection = await icnsAdapter.getICNSCollection();
-      
-
-      this.collections = uniqueTokens([...this.collections, icnsCollection, ...collectionWithTokens]) as NFTCollection[]
-
-
+      this.collections = await this.populateAndTrimNFTs(collections);
       return this.collections;
     } catch (e) {
       console.warn(
@@ -203,7 +204,7 @@ class PlugWallet {
   public transferNFT = async (args: {
     token: NFTDetails;
     to: string;
-  }): Promise<NFTCollection[]> => {
+  }): Promise<WalletNFTCollection[]> => {
     const { token, to } = args;
     if (!validatePrincipalId(to)) {
       throw new Error(ERRORS.INVALID_PRINCIPAL_ID);

--- a/src/constants/version.ts
+++ b/src/constants/version.ts
@@ -1,1 +1,1 @@
-export const PLUG_CONTROLLER_VERSION = "0.21.2";
+export const PLUG_CONTROLLER_VERSION = "0.22.0";

--- a/src/constants/version.ts
+++ b/src/constants/version.ts
@@ -1,1 +1,1 @@
-export const PLUG_CONTROLLER_VERSION = "0.21.1";
+export const PLUG_CONTROLLER_VERSION = "0.21.2";

--- a/src/interfaces/plug_wallet.ts
+++ b/src/interfaces/plug_wallet.ts
@@ -62,3 +62,14 @@ export interface JSONWallet {
     type: Types;
     keyPair: string;
 }
+
+export interface NFTDetailsBase<idT = bigint> {
+    index: idT;
+    canister: string;
+    url: string;
+    standard: string;
+}
+  
+export interface WalletNFTCollection extends Omit<NFTCollection, 'tokens'> {
+    tokens: NFTDetailsBase<bigint | string>[];
+}


### PR DESCRIPTION
## Summary
- Added `WalletNFTCollection` and `NFTDetailsBase` interfaces representing trimmed down versions of `dab-js`'s interfaces.
- Only store and return to front-end this trimmed down version of collections to prevent memory crashes.