### PR TITLE
Fix: dip721 custom nfts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@dfinity/identity": "0.9.3",
     "@dfinity/principal": "0.9.3",
     "@psychedelic/cap-js": "0.0.7",
-    "@psychedelic/dab-js": "1.5.0-beta.1",
+    "@psychedelic/dab-js": "1.5.0-beta.4",
     "@types/secp256k1": "^4.0.3",
     "axios": "^0.21.1",
     "babel-jest": "^25.5.1",
@@ -58,7 +58,7 @@
     "typescript": "^4.5"
   },
   "name": "@psychedelic/plug-controller",
-  "version": "0.24.6",
+  "version": "0.24.7",
   "description": "Internet Computer Plug wallet's controller",
   "main": "dist/index.js",
   "scripts": {

--- a/src/constants/version.ts
+++ b/src/constants/version.ts
@@ -1,1 +1,1 @@
-export const PLUG_CONTROLLER_VERSION = "0.24.6";
+export const PLUG_CONTROLLER_VERSION = "0.24.7";

--- a/yarn.lock
+++ b/yarn.lock
@@ -799,10 +799,10 @@
     axios "^0.24.0"
     cross-fetch "^3.1.4"
 
-"@psychedelic/dab-js@1.5.0-beta.1":
-  version "1.5.0-beta.1"
-  resolved "https://npm.pkg.github.com/download/@Psychedelic/dab-js/1.5.0-beta.1/306e2bb10491927995a3a22f25cd2ca9fd40990e#306e2bb10491927995a3a22f25cd2ca9fd40990e"
-  integrity sha512-p7GEh++Fv8U1SIYdqjxLLNy3I8fjoEF+lrXsHHKxcFuKpINxWkfWmUxLnjS6rytY+VuovrDEISFD4Tz0QHD2DQ==
+"@psychedelic/dab-js@1.5.0-beta.4":
+  version "1.5.0-beta.4"
+  resolved "https://npm.pkg.github.com/download/@Psychedelic/dab-js/1.5.0-beta.4/efd377970c28a917a93e933a96cbf0013d3c5a61#efd377970c28a917a93e933a96cbf0013d3c5a61"
+  integrity sha512-A5AKfXUyu7OLJwyv9hT7dVp6zZ01F/QKnLCu4yc7/KpbxQ8V7CvVYp6Jap5Ig06tGYz/XJu2HDLMUxrrIogWxg==
   dependencies:
     "@dfinity/agent" "0.9.3"
     "@dfinity/candid" "0.9.3"


### PR DESCRIPTION
## Summary
- Added latest dab-js version 1.5.0-beta.5 with legacy guards for dip721 custom nfts